### PR TITLE
.gitignore: Add osx images files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# OSX Files
+.DS_Store


### PR DESCRIPTION
Adds a basic .gitignore file to prevent checking in random os files (.DS_Store)